### PR TITLE
Convert more stuff

### DIFF
--- a/MarkdownToSteam/CodeInlineRendererBBCode.cs
+++ b/MarkdownToSteam/CodeInlineRendererBBCode.cs
@@ -1,0 +1,16 @@
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax.Inlines;
+
+namespace MarkdownToSteam
+{
+    internal class CodeInlineRendererBBCode : HtmlObjectRenderer<CodeInline>
+    {
+        protected override void Write(HtmlRenderer renderer, CodeInline obj)
+        {
+            renderer.Write("[i]");
+            renderer.Write(obj.ContentSpan);
+            renderer.Write("[/i]");
+        }
+    }
+}

--- a/MarkdownToSteam/EmphasisInlineRendererBbCode.cs
+++ b/MarkdownToSteam/EmphasisInlineRendererBbCode.cs
@@ -1,0 +1,34 @@
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax.Inlines;
+
+namespace MarkdownToSteam
+{
+    internal class EmphasisInlineRendererBbCode : HtmlObjectRenderer<EmphasisInline>
+    {
+        protected override void Write(HtmlRenderer renderer, EmphasisInline obj)
+        {
+            var tag = obj.DelimiterChar switch
+            {
+                '*' or '_' when obj.DelimiterCount == 1 => "i",
+                '*' or '_' when obj.DelimiterCount == 2 => "b",
+                '~' when obj.DelimiterCount == 2 => "strike",
+                _ => null
+            };
+
+            if (tag == null) {
+                for (int i = 0; i < obj.DelimiterCount; i++)
+                    renderer.Write(obj.DelimiterChar);
+            } else {
+                renderer.Write($"[{tag}]");
+            }
+            renderer.WriteChildren(obj);
+            if (tag == null) {
+                for (int i = 0; i < obj.DelimiterCount; i++)
+                    renderer.Write(obj.DelimiterChar);
+            } else {
+                renderer.Write($"[/{tag}]");
+            }
+        }
+    }
+}

--- a/MarkdownToSteam/Program.cs
+++ b/MarkdownToSteam/Program.cs
@@ -83,6 +83,7 @@ namespace MarkdownToSteam
 
 			
 			var renderer = new HtmlRenderer(writer);
+			renderer.EnableHtmlEscape = false;
 
 			renderer.ObjectWriteBefore += Renderer_ObjectWriteBefore;
 			bool removeResult;
@@ -95,6 +96,9 @@ namespace MarkdownToSteam
 			removeResult = renderer.ObjectRenderers.Replace<HeadingRenderer>(new HeadingRendererBbCode());
 			removeResult = renderer.ObjectRenderers.Replace<LinkInlineRenderer>(new LinkInlineRendererBbCode());
 			removeResult = renderer.ObjectRenderers.Replace<LineBreakInlineRenderer>(new LineBreakInlineRendererBbCode());
+			removeResult = renderer.ObjectRenderers.Replace<EmphasisInlineRenderer>(new EmphasisInlineRendererBbCode());
+			removeResult = renderer.ObjectRenderers.Replace<QuoteBlockRenderer>(new QuoteBlockRendererBbCode());
+			removeResult = renderer.ObjectRenderers.Replace<CodeInlineRenderer>(new CodeInlineRendererBBCode());
 
 			
 

--- a/MarkdownToSteam/QuoteBlockRendererBbCode.cs
+++ b/MarkdownToSteam/QuoteBlockRendererBbCode.cs
@@ -1,0 +1,21 @@
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+
+namespace MarkdownToSteam
+{
+    internal class QuoteBlockRendererBbCode : HtmlObjectRenderer<QuoteBlock>
+    {
+        protected override void Write(HtmlRenderer renderer, QuoteBlock obj)
+        {
+            renderer.EnsureLine();
+            renderer.Write("[quote]");
+            bool implicitParagraph = renderer.ImplicitParagraph;
+            renderer.ImplicitParagraph = false;
+            renderer.WriteChildren(obj);
+            renderer.ImplicitParagraph = implicitParagraph;
+            renderer.WriteLine("[/quote]");
+            renderer.EnsureLine();
+        }
+    }
+}


### PR DESCRIPTION
- bold
- italics
- quotes
- don't escape stuff like & or "
- inline code gets turned into italics. not perfect but there's no real equivalent.